### PR TITLE
Update syntax.php for PHP warning

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base authorlist
 author Martin Schulte, Vladimir Kuzmin
 email jl.alice@yandex.ru
-date 2017-01-04
+date 2024-06-11
 name authorlist Plugin
 desc Displays all contributors/authors of a wikipage
 url https://dokuwiki.org/plugin:authorlist

--- a/syntax.php
+++ b/syntax.php
@@ -91,8 +91,12 @@ class syntax_plugin_authorlist extends DokuWiki_Syntax_Plugin {
     * Render the complete authorlist. 
     */
     function render($mode, Doku_Renderer $renderer, $data) {
-		// Only if XHTML
-        if($mode == 'xhtml' && !$data['off']){
+        // Only if XHTML
+        $func_on = true;
+        if(isset($data['off']) && $data['off']) {
+                $func_on = false;
+        }
+        if($mode == 'xhtml' && $func_on){
 			global $INFO;
 			$al = &plugin_load('helper', 'authorlist'); // A helper_plugin_authorlist object
 			if (!$al) return false; // Everything went well?


### PR DESCRIPTION
```
PHP Warning:  Undefined array key "off" in /var/www/html/doku/lib/plugins/authorlist/syntax.php on line 95, referer: http://x.x.x.x/doku/doku.php
```

Tested:

* A new page without `~~AUTHORS:off~~`, show one `Contributing authors xxxx` as normal.
* A new page with `~~AUTHORS:off~~`, show no `Contributing authors xxxx` as wanted.
* A new page with `~~AUTHORS:on~~`, show two `Contributing authors xxxx` as normal.

